### PR TITLE
Make dom safe: remove $UNSAFE, use bridge dom_flush

### DIFF
--- a/bats.toml
+++ b/bats.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasm.bats-packages.dev/dom"
 kind = "lib"
-unsafe = true
+unsafe = false
 
 [dependencies]
 "wasm.bats-packages.dev/bridge" = ""

--- a/src/lib.bats
+++ b/src/lib.bats
@@ -178,14 +178,9 @@ assume document(l) = doc_vt(l)
 
 in
 
-extern fun _bats_dom_flush_raw
-  (buf: ptr, len: int): void = "mac#bats_dom_flush"
-
 fn _flush_arr{l:agz}
   (buf: !$A.arr(byte, l, DOM_BUF_CAP), len: int): void =
-  _bats_dom_flush_raw(
-    $UNSAFE begin $UNSAFE.castvwtp1{ptr}(buf) end,
-    len)
+  $B.dom_flush(buf, len)
 
 fn _auto_flush
   {l:agz}{needed:pos | needed <= DOM_BUF_CAP}


### PR DESCRIPTION
Bridge already wraps the unsafe ptr cast. dom now uses it directly. unsafe=false.